### PR TITLE
No paths

### DIFF
--- a/test/has_scope_test.rb
+++ b/test/has_scope_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/test_helper'
+require 'test_helper'
 
 class Tree
 end


### PR DESCRIPTION
Had a good conversation with José where he pointed out that the setup of the paths should be done outside of the files doing the requiring, which lets us nicely/correctly just require 'test_helper' in this case. So, quick change here that seems to be moving things in a good way, and also let me run the tests quickly under 1.9.2
