### PR TITLE
Apply helper_method only on ActionController::Base

### DIFF
--- a/lib/has_scope.rb
+++ b/lib/has_scope.rb
@@ -11,7 +11,6 @@ module HasScope
   def self.included(base)
     base.class_eval do
       extend ClassMethods
-      helper_method :current_scopes
       class_attribute :scopes_configuration, :instance_writer => false
     end
   end
@@ -184,4 +183,7 @@ module HasScope
   end
 end
 
-ActionController::Base.send :include, HasScope
+ActionController::Base.instance_eval do
+  include HasScope
+  helper_method :current_scopes
+end

--- a/test/has_scope_test.rb
+++ b/test/has_scope_test.rb
@@ -247,3 +247,22 @@ class HasScopeTest < ActionController::TestCase
     end
 end
 
+class TreeHugger
+  include HasScope
+
+  has_scope :color
+
+  def by_color
+    apply_scopes(Tree, :color => 'blue')
+  end
+
+end
+
+class HasScopeOutsideControllerTest < ActiveSupport::TestCase
+
+  def test_has_scope_usable_outside_controller
+    Tree.expects(:color).with('blue')
+    TreeHugger.new.by_color
+  end
+
+end


### PR DESCRIPTION
This way, HasScope can be included in every class.
