### PR TITLE
default value as a proc without argument

### DIFF
--- a/lib/has_scope.rb
+++ b/lib/has_scope.rb
@@ -111,7 +111,9 @@ module HasScope
         value, call_scope = hash[key], true
       elsif options.key?(:default)
         value, call_scope = options[:default], true
-        value = value.call(self) if value.is_a?(Proc)
+        if value.is_a?(Proc)
+          value = value.arity == 0 ? value.call : value.call(self)
+        end
       end
 
       value = parse_value(options[:type], key, value)

--- a/test/has_scope_test.rb
+++ b/test/has_scope_test.rb
@@ -8,6 +8,7 @@ class TreesController < ApplicationController
   has_scope :only_tall, :type => :boolean, :only => :index, :if => :restrict_to_only_tall_trees?
   has_scope :shadown_range, :default => 10, :except => [ :index, :show, :new ]
   has_scope :root_type, :as => :root, :allow_blank => true
+  has_scope :planted_before, :default => proc { Date.today }
   has_scope :calculate_height, :default => proc {|c| c.session[:height] || 20 }, :only => :new
   has_scope :paginate, :type => :hash
   has_scope :args_paginate, :type => :hash, :using => [:page, :per_page]
@@ -201,7 +202,16 @@ class HasScopeTest < ActionController::TestCase
     assert_equal({ :root => 'outside' }, current_scopes)
   end
 
-  def test_scope_with_default_value_as_proc
+  def test_scope_with_default_value_as_a_proc_without_argument
+    Date.expects(:today).returns("today")
+    Tree.expects(:planted_before).with("today").returns(Tree)
+    Tree.expects(:all).returns([mock_tree])
+    get :index
+    assert_equal([mock_tree], assigns(:trees))
+    assert_equal({ :planted_before => "today" }, current_scopes)
+  end
+
+  def test_scope_with_default_value_as_proc_with_argument
     session[:height] = 100
     Tree.expects(:calculate_height).with(100).returns(Tree).in_sequence
     Tree.expects(:new).returns(mock_tree).in_sequence


### PR DESCRIPTION
Sometimes, for example when the scope is a date, or time, it's good to use proc to define default value, and then syntax like this:
has_scope :at, :default => ->(controller) { Date.today }
is too cluttered, as we don't need anything from controller.
