### PR TITLE
Adding "passable_boolean" scope with tests.

### DIFF
--- a/test/has_scope_test.rb
+++ b/test/has_scope_test.rb
@@ -13,6 +13,8 @@ class TreesController < ApplicationController
   has_scope :args_paginate, :type => :hash, :using => [:page, :per_page]
   has_scope :categories, :type => :array
 
+  has_scope :alive, :type => :passable_boolean, :only => :index
+
   has_scope :only_short, :type => :boolean do |controller, scope|
     scope.only_really_short!(controller.object_id)
   end
@@ -265,6 +267,22 @@ class HasScopeTest < ActionController::TestCase
      assert_nil(TreesController.scopes_configuration[:categories][:if])
      assert_equal(:categories?, BonsaisController.scopes_configuration[:categories][:if])
    end
+
+  def test_passable_boolean_scope_is_called_when_boolean_param_is_true
+    Tree.expects(:alive).with(true).returns(Tree).in_sequence
+    Tree.expects(:all).returns([mock_tree])
+    get :index, :alive => 'true'
+    assert_equal([mock_tree], assigns(:trees))
+    assert_equal({ :alive => true }, current_scopes)
+  end
+
+  def test_passable_boolean_scope_is_still_called_when_boolean_param_is_false
+    Tree.expects(:alive).with(false).returns(Tree).in_sequence
+    Tree.expects(:all).returns([mock_tree])
+    get :index, :alive => 'false'
+    assert_equal([mock_tree], assigns(:trees))
+    assert_equal({ :alive => false }, current_scopes)
+  end
 
   protected
 


### PR DESCRIPTION
I mentioned in issue #13 that I wasn't crazy about my own implementation of this, but I'm putting it up here so it can be discussed and tweaked upon and improved (because hey, it's been 3 years)!

This adds the ability to pass true/false into a controller scope that has a model scope accepting the boolean on the backend.

Once it's settled on how to go about this, I'll update my PR with the appropriate clauses in the readme.
