### PR TITLE
Added `"on"` to `HasScope::TRUE_VALUES`

### DIFF
--- a/lib/has_scope.rb
+++ b/lib/has_scope.rb
@@ -1,5 +1,5 @@
 module HasScope
-  TRUE_VALUES = ["true", true, "1", 1]
+  TRUE_VALUES = ["on", "true", true, "1", 1]
 
   ALLOWED_TYPES = {
     :array   => [ Array ],

--- a/test/has_scope_test.rb
+++ b/test/has_scope_test.rb
@@ -68,6 +68,14 @@ class HasScopeTest < ActionController::TestCase
     assert_equal({ :only_tall => true }, current_scopes)
   end
 
+  def test_boolean_scope_is_called_when_boolean_param_is_on
+    Tree.expects(:only_tall).with().returns(Tree).in_sequence
+    Tree.expects(:all).returns([mock_tree]).in_sequence
+    get :index, :only_tall => 'on'
+    assert_equal([mock_tree], assigns(:trees))
+    assert_equal({ :only_tall => true }, current_scopes)
+  end
+
   def test_boolean_scope_is_not_called_when_boolean_param_is_false
     Tree.expects(:only_tall).never
     Tree.expects(:all).returns([mock_tree])


### PR DESCRIPTION
Adds `"on"` as an acceptable truthy value for a `type: :boolean` scope (for use with checkboxes).
