### PR TITLE
Allow symbols in default type.

### DIFF
--- a/lib/has_scope.rb
+++ b/lib/has_scope.rb
@@ -5,7 +5,7 @@ module HasScope
     :array   => [ Array ],
     :hash    => [ Hash ],
     :boolean => [ Object ],
-    :default => [ String, Numeric ]
+    :default => [ String, Numeric, Symbol ]
   }
 
   def self.included(base)


### PR DESCRIPTION
There _may_ be some sort of vulnerability or rational here I'm not aware of, but:

One possible point of entry for for params is in routing constraints, which can set parameters as symbols instead of strings.

An alternative solution could be to make a `:symbol` type.
