### PR TITLE
Execute blocks in controller's context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Scope blocks are executed in controller's context
 * Boolean scopes with `allow_blank: true` are called with values, working as any other scopes
 * Add `:in` option: a shortcut for combining the `:using` option with nested hashes
 * Support Rails 4.1

--- a/README.md
+++ b/README.md
@@ -110,12 +110,12 @@ scope :active, ->(value = true) { where(active: value) }
 
 ## Block usage
 
-`has_scope` also accepts a block. The controller, current scope and value are yielded
-to the block so the user can apply the scope on its own. This is useful in case we
-need to manipulate the given value:
+`has_scope` also accepts a block. Block is executed in controller's context,
+current scope and value are yielded so the user can apply the scope on its own.
+This is useful in case we need to manipulate the given value:
 
 ```ruby
-has_scope :category do |controller, scope, value|
+has_scope :category do |scope, value|
   value != "all" ? scope.by_category(value) : scope
 end
 ```
@@ -124,7 +124,7 @@ When used with booleans without `:allow_blank`, it just receives two arguments
 and is just invoked if true is given:
 
 ```ruby
-has_scope :not_voted_by_me, :type => :boolean do |controller, scope|
+has_scope :not_voted_by_me, :type => :boolean do |scope|
   scope.not_voted_by(controller.current_user.id)
 end
 ```

--- a/lib/has_scope.rb
+++ b/lib/has_scope.rb
@@ -158,12 +158,12 @@ module HasScope
     block = options[:block]
 
     if type == :boolean && !options[:allow_blank]
-      block ? block.call(self, target) : target.send(scope)
+      block ? instance_exec(target, &block) : target.send(scope)
     elsif value && options.key?(:using)
       value = value.values_at(*options[:using])
-      block ? block.call(self, target, value) : target.send(scope, *value)
+      block ? instance_exec(target, value, &block) : target.send(scope, *value)
     else
-      block ? block.call(self, target, value) : target.send(scope, value)
+      block ? instance_exec(target, value, &block) : target.send(scope, value)
     end
   end
 

--- a/test/has_scope_test.rb
+++ b/test/has_scope_test.rb
@@ -17,12 +17,12 @@ class TreesController < ApplicationController
   has_scope :content, :in => :q
   has_scope :conifer, type: :boolean, :allow_blank => true
 
-  has_scope :only_short, :type => :boolean do |controller, scope|
-    scope.only_really_short!(controller.object_id)
+  has_scope :only_short, :type => :boolean do |scope|
+    scope.only_really_short!(object_id)
   end
 
-  has_scope :by_category do |controller, scope, value|
-    scope.by_given_category(controller.object_id, value + "_id")
+  has_scope :by_category do |scope, value|
+    scope.by_given_category(object_id, value + "_id")
   end
 
   def index


### PR DESCRIPTION
It includes changes from #55. Check the last commit please.

It uses `instance_exec`, i'm not sure it's supported by ruby 1.8.

It also breaks backward compatibility, but i think this way is more expectable, just like any controller filter.
