### PR TITLE
Allow custom types and parsers

### DIFF
--- a/test/has_scope_test.rb
+++ b/test/has_scope_test.rb
@@ -1,5 +1,10 @@
 require 'test_helper'
 
+HasScope.allowed_types[:date] = [
+  [String],
+  lambda {|v| Date.parse(v) rescue nil }
+]
+
 class Tree
 end
 
@@ -9,6 +14,7 @@ class TreesController < ApplicationController
   has_scope :shadown_range, :default => 10, :except => [ :index, :show, :new ]
   has_scope :root_type, :as => :root, :allow_blank => true
   has_scope :planted_before, :default => proc { Date.today }
+  has_scope :planted_after, :type => :date
   has_scope :calculate_height, :default => proc {|c| c.session[:height] || 20 }, :only => :new
   has_scope :paginate, :type => :hash
   has_scope :args_paginate, :type => :hash, :using => [:page, :per_page]
@@ -280,6 +286,15 @@ class HasScopeTest < ActionController::TestCase
     get :new
     assert_equal(mock_tree, assigns(:tree))
     assert_equal({ :calculate_height => 100 }, current_scopes)
+  end
+
+  def test_scope_with_custom_type
+    parsed = Date.civil(2014,11,11)
+    Tree.expects(:planted_after).with(parsed).returns(Tree)
+    Tree.expects(:all).returns([mock_tree])
+    get :index, :planted_after => "2014-11-11"
+    assert_equal([mock_tree], assigns(:trees))
+    assert_equal({ :planted_after => parsed }, current_scopes)
   end
 
   def test_scope_with_boolean_block


### PR DESCRIPTION
It would be nice if has_scope could handle custom types and parsers. This patch is very simplistic and gives the users the ability for basic overrides.
