### PR TITLE
fix, add explicit requires to ensure constants are available.

### DIFF
--- a/lib/has_scope.rb
+++ b/lib/has_scope.rb
@@ -1,3 +1,8 @@
+require 'active_support'
+require 'active_support/core_ext/string/strip'
+require 'action_controller'
+require 'action_dispatch/middleware/flash'
+
 module HasScope
   TRUE_VALUES = ["true", true, "1", 1]
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,11 +7,6 @@ require 'mocha/mini_test'
 # Configure Rails
 ENV['RAILS_ENV'] = 'test'
 
-require 'active_support'
-require 'active_support/core_ext/string/strip'
-require 'action_controller'
-require 'action_dispatch/middleware/flash'
-
 $:.unshift File.expand_path('../../lib', __FILE__)
 require 'has_scope'
 


### PR DESCRIPTION
We have run into a production issue that would only manifest in
combination with `sidekiqswarm`. The gist is that swarm uses
`Bundler.require(*groups)` to preload gems before forking. After
removing some of our dependencies, we were left in a state where
`action_controller` was not required when `has_scope` is
loaded. Resulting in a `uninitialized constant HasScope::ActionController (NameError)`.

This patch moves the requires from `test_helper.rb` into the gem to
ensure these files are loaded.

**Error:**
```
/Users/senny/.rbenv/versions/2.6.6/bin/ruby -w -I"lib:lib:test" -I"/Users/senny/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rake-13.0.1/lib" "/Users/senny/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb" "test/has_scope_test.rb"
Traceback (most recent call last):
	11: from /Users/senny/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:5:in `<main>'
	10: from /Users/senny/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:5:in `select'
	 9: from /Users/senny/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:17:in `block in <main>'
	 8: from /Users/senny/.rbenv/versions/2.6.6/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	 7: from /Users/senny/.rbenv/versions/2.6.6/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	 6: from /Users/senny/Projects/github/has_scope/test/has_scope_test.rb:1:in `<top (required)>'
	 5: from /Users/senny/.rbenv/versions/2.6.6/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	 4: from /Users/senny/.rbenv/versions/2.6.6/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	 3: from /Users/senny/Projects/github/has_scope/test/test_helper.rb:15:in `<top (required)>'
	 2: from /Users/senny/Projects/github/has_scope/test/test_helper.rb:15:in `require'
	 1: from /Users/senny/Projects/github/has_scope/lib/has_scope.rb:1:in `<top (required)>'
/Users/senny/Projects/github/has_scope/lib/has_scope.rb:6:in `<module:HasScope>': uninitialized constant HasScope::ActionController (NameError)
rake aborted!
Command failed with status (1): [ruby -w -I"lib:lib:test" -I"/Users/senny/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rake-13.0.1/lib" "/Users/senny/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb" "test/has_scope_test.rb" ]

Tasks: TOP => test
(See full trace by running task with --trace)
```