### PR TITLE
Deprecate usage of eval for code evaluation for if/unless options

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ HasScope supports several options:
 
 * `:in` - A shortcut for combining the `:using` option with nested hashes.
 
-* `:if` - Specifies a method, proc or string to call to determine if the scope should apply.
+* `:if` - Specifies a method or proc to call to determine if the scope should apply. Passing a string is deprecated and it will be removed in a future version.
 
-* `:unless` - Specifies a method, proc or string to call to determine if the scope should NOT apply.
+* `:unless` - Specifies a method or proc to call to determine if the scope should NOT apply. Passing a string is deprecated and it will be removed in a future version.
 
 * `:default` - Default value for the scope. Whenever supplied the scope is always called.
 

--- a/lib/has_scope.rb
+++ b/lib/has_scope.rb
@@ -190,6 +190,11 @@ module HasScope
   def applicable?(string_proc_or_symbol, expected) #:nodoc:
     case string_proc_or_symbol
     when String
+      ActiveSupport::Deprecation.warn <<-DEPRECATION.squish
+        [HasScope] Passing a string to determine if the scope should be applied
+        is deprecated and it will be removed in a future version of HasScope.
+      DEPRECATION
+
       eval(string_proc_or_symbol) == expected
     when Proc
       string_proc_or_symbol.call(self) == expected

--- a/test/has_scope_test.rb
+++ b/test/has_scope_test.rb
@@ -161,6 +161,15 @@ class HasScopeTest < ActionController::TestCase
     assert_equal({ eval_plant: 'value' }, current_scopes)
   end
 
+  def test_deprecated_scope_with_eval_string_if_and_unless_options
+    Tree.expects(:eval_plant).with('value').returns(Tree)
+    Tree.expects(:all).returns([mock_tree])
+
+    assert_deprecated(/Passing a string to determine if the scope should be applied is deprecated/) do
+      get :index, params: { eval_plant: 'value', skip_eval_plant: nil }
+    end
+  end
+
   def test_scope_with_proc_if_and_unless_options
     Tree.expects(:proc_plant).with('value').returns(Tree)
     Tree.expects(:all).returns([mock_tree])


### PR DESCRIPTION
The scope where `eval()` is being used here is okay, but using it for code evaluation is tricky.  This is the first step to stop the usage of `eval` for code evaluation. This PR deprecates passing a string to determine if the scope should be applied or not.