### PR TITLE
Support overwriting scope blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Support overwriting scope blocks (#126)
 * Ruby 4.0 support (no changes required)
 
 ## 0.9.0

--- a/lib/has_scope.rb
+++ b/lib/has_scope.rb
@@ -96,6 +96,7 @@ module HasScope
 
       options[:only]   = Array(options[:only])
       options[:except] = Array(options[:except])
+      options[:block] = block if block
 
       self.scopes_configuration = scopes_configuration.dup
 

--- a/lib/has_scope.rb
+++ b/lib/has_scope.rb
@@ -96,7 +96,7 @@ module HasScope
 
       options[:only]   = Array(options[:only])
       options[:except] = Array(options[:except])
-      options[:block] = block if block
+      options[:block]  = block if block
 
       self.scopes_configuration = scopes_configuration.dup
 

--- a/test/has_scope_test.rb
+++ b/test/has_scope_test.rb
@@ -76,6 +76,9 @@ end
 
 class BonsaisController < TreesController
   has_scope :categories, if: :categories?
+  has_scope :content do |controller, scope|
+    scope.by_content('some other content')
+  end
 
   protected
     def categories?
@@ -481,6 +484,11 @@ class HasScopeTest < ActionController::TestCase
   def test_overwritten_scope
     assert_nil(TreesController.scopes_configuration[:categories][:if])
     assert_equal(:categories?, BonsaisController.scopes_configuration[:categories][:if])
+  end
+
+  def test_overwritten_scope_with_block
+    assert_nil(TreesController.scopes_configuration[:content][:block])
+    assert(BonsaisController.scopes_configuration[:content][:block])
   end
 
   protected

--- a/test/has_scope_test.rb
+++ b/test/has_scope_test.rb
@@ -481,16 +481,6 @@ class HasScopeTest < ActionController::TestCase
     assert_equal({ q: hash }, current_scopes)
   end
 
-  def test_overwritten_scope
-    assert_nil(TreesController.scopes_configuration[:categories][:if])
-    assert_equal(:categories?, BonsaisController.scopes_configuration[:categories][:if])
-  end
-
-  def test_overwritten_scope_with_block
-    assert_nil(TreesController.scopes_configuration[:content][:block])
-    assert(BonsaisController.scopes_configuration[:content][:block])
-  end
-
   protected
 
     def mock_tree(stubs = {})
@@ -499,6 +489,38 @@ class HasScopeTest < ActionController::TestCase
 
     def current_scopes
       @controller.send :current_scopes
+    end
+
+    def assigns(ivar)
+      @controller.instance_variable_get(ivar)
+    end
+end
+
+class HasScopeOverridesTest < ActionController::TestCase
+  tests BonsaisController
+
+  def test_overwritten_scopes_configuration
+    assert_nil(TreesController.scopes_configuration[:categories][:if])
+    assert_equal(:categories?, BonsaisController.scopes_configuration[:categories][:if])
+
+    assert_nil(TreesController.scopes_configuration[:content][:block])
+    assert(BonsaisController.scopes_configuration[:content][:block])
+  end
+
+  def test_overwritten_scope_block_is_called
+    Tree.expects(:by_content).with('some other content').returns(Tree)
+    Tree.expects(:metadata_blank).with(nil).returns(Tree)
+    Tree.expects(:all).returns([mock_tree])
+
+    get :index, params: { q: { content: 'the-content' } }
+
+    assert_equal([mock_tree], assigns(:@trees))
+  end
+
+  protected
+
+    def mock_tree(stubs = {})
+      @mock_tree ||= mock(stubs)
     end
 
     def assigns(ivar)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,7 @@ require 'has_scope'
 HasScope::Routes = ActionDispatch::Routing::RouteSet.new
 HasScope::Routes.draw do
   resources :trees, only: %i[index new edit show]
+  resources :bonsais, only: %i[index]
 end
 
 class ApplicationController < ActionController::Base


### PR DESCRIPTION
Previously, block was only able to be configured via the first scope definition. If it was redefined to add a scope or change the scope, it wouldn't get configured due to the conditional assignment operator. The current limitation is that we cannot unset the block if it's set in a parent. The only way to do it would be to pass an empty block.

```ruby
has_scope :some_scope do |controller, scope|
  scope.something(...)
end

# overwritten block for scope
has_scope :some_scope { # no-op }
``` 